### PR TITLE
Prevent <input> element re-rendering if tooltip visibility is changed

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -191,91 +191,121 @@ function _nonIterableRest() {
 }
 
 var DEFAULT_CLASS_PREFIX = 'range-slider';
-var RangeSlider = /*#__PURE__*/React__default.forwardRef(function (_ref, ref) {
-  var size = _ref.size,
-      _ref$disabled = _ref.disabled,
-      disabled = _ref$disabled === void 0 ? false : _ref$disabled,
-      value = _ref.value,
-      _ref$onChange = _ref.onChange,
-      _onChange = _ref$onChange === void 0 ? function () {} : _ref$onChange,
-      _ref$onAfterChange = _ref.onAfterChange,
-      onAfterChange = _ref$onAfterChange === void 0 ? function () {} : _ref$onAfterChange,
-      _ref$min = _ref.min,
-      min = _ref$min === void 0 ? 0 : _ref$min,
-      _ref$max = _ref.max,
-      max = _ref$max === void 0 ? 100 : _ref$max,
-      step = _ref.step,
-      _ref$variant = _ref.variant,
-      variant = _ref$variant === void 0 ? 'primary' : _ref$variant,
-      _ref$inputProps = _ref.inputProps,
-      inputProps = _ref$inputProps === void 0 ? {} : _ref$inputProps,
-      _ref$tooltip = _ref.tooltip,
-      tooltip = _ref$tooltip === void 0 ? 'auto' : _ref$tooltip,
-      _ref$tooltipPlacement = _ref.tooltipPlacement,
-      tooltipPlacement = _ref$tooltipPlacement === void 0 ? 'bottom' : _ref$tooltipPlacement,
-      tooltipLabel = _ref.tooltipLabel,
-      _ref$tooltipStyle = _ref.tooltipStyle,
-      tooltipStyle = _ref$tooltipStyle === void 0 ? {} : _ref$tooltipStyle,
-      _ref$tooltipProps = _ref.tooltipProps,
-      tooltipProps = _ref$tooltipProps === void 0 ? {} : _ref$tooltipProps,
-      bsPrefix = _ref.bsPrefix,
-      className = _ref.className;
+
+var Input = function Input(_ref) {
+  var classes = _ref.classes,
+      _onChange = _ref.onChange,
+      onMouseUpOrTouchEnd = _ref.onMouseUpOrTouchEnd,
+      _onTouchEnd = _ref.onTouchEnd,
+      _onMouseUp = _ref.onMouseUp,
+      rest = _objectWithoutProperties(_ref, ["classes", "onChange", "onMouseUpOrTouchEnd", "onTouchEnd", "onMouseUp"]);
+
+  return /*#__PURE__*/React__default.createElement("input", _extends({
+    type: "range",
+    onChange: function onChange(ev) {
+      return _onChange(ev, ev.target.valueAsNumber);
+    },
+    onMouseUp: function onMouseUp(ev) {
+      onMouseUpOrTouchEnd(ev);
+      if (_onMouseUp) _onMouseUp(ev);
+    },
+    onTouchEnd: function onTouchEnd(ev) {
+      onMouseUpOrTouchEnd(ev);
+      if (_onTouchEnd) _onTouchEnd(ev);
+    },
+    className: classes
+  }, rest));
+};
+
+Input.propTypes = {
+  classes: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onMouseUpOrTouchEnd: PropTypes.func.isRequired,
+  onTouchEnd: PropTypes.func,
+  onMouseUp: PropTypes.func
+};
+var InputMemo = /*#__PURE__*/React__default.memo(Input);
+var RangeSlider = /*#__PURE__*/React__default.forwardRef(function (_ref2, ref) {
+  var size = _ref2.size,
+      _ref2$disabled = _ref2.disabled,
+      disabled = _ref2$disabled === void 0 ? false : _ref2$disabled,
+      value = _ref2.value,
+      _ref2$onChange = _ref2.onChange,
+      onChange = _ref2$onChange === void 0 ? function () {} : _ref2$onChange,
+      _ref2$onAfterChange = _ref2.onAfterChange,
+      onAfterChange = _ref2$onAfterChange === void 0 ? function () {} : _ref2$onAfterChange,
+      _ref2$min = _ref2.min,
+      min = _ref2$min === void 0 ? 0 : _ref2$min,
+      _ref2$max = _ref2.max,
+      max = _ref2$max === void 0 ? 100 : _ref2$max,
+      step = _ref2.step,
+      _ref2$variant = _ref2.variant,
+      variant = _ref2$variant === void 0 ? 'primary' : _ref2$variant,
+      _ref2$inputProps = _ref2.inputProps,
+      inputProps = _ref2$inputProps === void 0 ? {} : _ref2$inputProps,
+      _ref2$tooltip = _ref2.tooltip,
+      tooltip = _ref2$tooltip === void 0 ? 'auto' : _ref2$tooltip,
+      _ref2$tooltipPlacemen = _ref2.tooltipPlacement,
+      tooltipPlacement = _ref2$tooltipPlacemen === void 0 ? 'bottom' : _ref2$tooltipPlacemen,
+      tooltipLabel = _ref2.tooltipLabel,
+      _ref2$tooltipStyle = _ref2.tooltipStyle,
+      tooltipStyle = _ref2$tooltipStyle === void 0 ? {} : _ref2$tooltipStyle,
+      _ref2$tooltipProps = _ref2.tooltipProps,
+      tooltipProps = _ref2$tooltipProps === void 0 ? {} : _ref2$tooltipProps,
+      bsPrefix = _ref2.bsPrefix,
+      className = _ref2.className;
 
   var _useState = React.useState(),
       _useState2 = _slicedToArray(_useState, 2),
-      prevValue = _useState2[0],
       setPrevValue = _useState2[1];
 
   var prefix = bsPrefix || DEFAULT_CLASS_PREFIX;
   var isTooltip = tooltip === 'auto' || tooltip === 'on';
   var classes = classNames(className, prefix, size && "".concat(prefix, "--").concat(size), disabled && 'disabled', variant && "".concat(prefix, "--").concat(variant));
 
-  var inputPropsOnMouseUp = inputProps.inputPropsOnMouseUp,
-      restInputProps = _objectWithoutProperties(inputProps, ["inputPropsOnMouseUp"]);
+  var onMouseUp = inputProps.onMouseUp,
+      onTouchEnd = inputProps.onTouchEnd,
+      restInputProps = _objectWithoutProperties(inputProps, ["onMouseUp", "onTouchEnd"]);
 
-  var inputEl = /*#__PURE__*/React__default.createElement("input", _extends({
-    type: "range",
-    className: classes,
+  var onMouseUpOrTouchEnd = React.useCallback(function (ev) {
+    setPrevValue(function (prevValue) {
+      if (prevValue !== ev.target.value) onAfterChange(ev, ev.target.valueAsNumber);
+      return ev.target.value;
+    });
+  }, [setPrevValue, onAfterChange]);
+  var inputEl = /*#__PURE__*/React__default.createElement(InputMemo, _objectSpread2({
+    disabled: disabled,
     value: value,
     min: min,
     max: max,
+    ref: ref,
     step: step,
-    onChange: function onChange(ev) {
-      return _onChange(ev, ev.target.valueAsNumber);
-    },
-    onMouseUp: function onMouseUp(ev) {
-      if (ev.target.value !== prevValue) onAfterChange(ev, ev.target.valueAsNumber);
-      setPrevValue(ev.target.value);
-      if (inputPropsOnMouseUp) inputPropsOnMouseUp(ev);
-    },
-    disabled: disabled,
-    ref: ref
+    classes: classes,
+    onMouseUpOrTouchEnd: onMouseUpOrTouchEnd,
+    onTouchEnd: onTouchEnd,
+    onMouseUp: onMouseUp,
+    onChange: onChange
   }, restInputProps));
+  var wrapClasses = classNames("".concat(prefix, "__wrap"), size && "".concat(prefix, "__wrap--").concat(size));
+  var tooltipClasses = classNames("".concat(prefix, "__tooltip"), isTooltip && "".concat(prefix, "__tooltip--").concat(tooltip), tooltipPlacement && "".concat(prefix, "__tooltip--").concat(tooltipPlacement), disabled && "".concat(prefix, "__tooltip--disabled"));
+  var thumbRadius = size === 'sm' ? 8 : size === 'lg' ? 12 : 10;
+  var fract = (value - min) / (max - min);
+  var percentLeft = fract * 100;
+  var fractFromCentre = (fract - 0.5) * 2;
+  var adjustment = fractFromCentre * -thumbRadius; // Half thumb width
 
-  if (isTooltip) {
-    var wrapClasses = classNames("".concat(prefix, "__wrap"), size && "".concat(prefix, "__wrap--").concat(size));
-    var tooltipClasses = classNames("".concat(prefix, "__tooltip"), isTooltip && "".concat(prefix, "__tooltip--").concat(tooltip), tooltipPlacement && "".concat(prefix, "__tooltip--").concat(tooltipPlacement), disabled && "".concat(prefix, "__tooltip--disabled"));
-    var thumbRadius = size === 'sm' ? 8 : size === 'lg' ? 12 : 10;
-    var fract = (value - min) / (max - min);
-    var percentLeft = fract * 100;
-    var fractFromCentre = (fract - 0.5) * 2;
-    var adjustment = fractFromCentre * -thumbRadius; // Half thumb width
-
-    return /*#__PURE__*/React__default.createElement("span", {
-      className: wrapClasses
-    }, inputEl, /*#__PURE__*/React__default.createElement("div", _extends({
-      className: tooltipClasses,
-      style: _objectSpread2(_objectSpread2({}, tooltipStyle || {}), {}, {
-        left: "calc(".concat(percentLeft, "% + ").concat(adjustment, "px)")
-      })
-    }, tooltipProps), /*#__PURE__*/React__default.createElement("div", {
-      className: "".concat(prefix, "__tooltip__label")
-    }, tooltipLabel ? tooltipLabel(value) : value), /*#__PURE__*/React__default.createElement("div", {
-      className: "".concat(prefix, "__tooltip__arrow")
-    })));
-  } else {
-    return inputEl;
-  }
+  return /*#__PURE__*/React__default.createElement("span", {
+    className: wrapClasses
+  }, inputEl, isTooltip && /*#__PURE__*/React__default.createElement("div", _extends({
+    className: tooltipClasses,
+    style: _objectSpread2(_objectSpread2({}, tooltipStyle || {}), {}, {
+      left: "calc(".concat(percentLeft, "% + ").concat(adjustment, "px)")
+    })
+  }, tooltipProps), /*#__PURE__*/React__default.createElement("div", {
+    className: "".concat(prefix, "__tooltip__label")
+  }, tooltipLabel ? tooltipLabel(value) : value), /*#__PURE__*/React__default.createElement("div", {
+    className: "".concat(prefix, "__tooltip__arrow")
+  })));
 }); // Fix: https://github.com/jaywilz/react-bootstrap-range-slider/issues/3
 
 var Element = typeof Element === 'undefined' ? function () {} : Element;

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,8 +78,8 @@
 
   const [ value, setValue ] = React.useState(50);
 
-  return ( 
-    &lt;Form> 
+  return (
+    &lt;Form>
       &lt;Form.Group>
         &lt;Form.Label>
           My Label
@@ -88,7 +88,7 @@
           value={value}
           onChange={e => setValue(e.target.value)}
         /&gt;
-      &lt;/Form.Group>   
+      &lt;/Form.Group>
     &lt;/Form>
   );
 
@@ -106,8 +106,8 @@
 
   const [ value, setValue ] = React.useState(50);
 
-  return ( 
-    &lt;Form> 
+  return (
+    &lt;Form>
       &lt;Form.Group as={Row}>
         &lt;Form.Label column sm="4">
           My Other Label
@@ -143,7 +143,7 @@
           &lt;RangeSlider
             value={value}
             onChange={e => setValue(e.target.value)}
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="3">
           &lt;Form.Control value={value}/>
@@ -179,7 +179,7 @@
             value={value1}
             onChange={e => setValue1(e.target.value)}
             size='sm'
-          /&gt;        
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
       &lt;Form.Group as={Row}>
@@ -190,7 +190,7 @@
           &lt;RangeSlider
             value={value2}
             onChange={e => setValue2(e.target.value)}
-          /&gt;        
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
       &lt;Form.Group as={Row}>
@@ -202,7 +202,7 @@
             value={value3}
             onChange={e => setValue3(e.target.value)}
             size='lg'
-          /&gt;        
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
       &lt;/Form>
@@ -237,28 +237,28 @@
             value={value1}
             onChange={e => setValue1(e.target.value)}
             variant='primary'
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="3">
           &lt;RangeSlider
             value={value2}
             onChange={e => setValue2(e.target.value)}
             variant='secondary'
-          /&gt;    
+          /&gt;
         &lt;/Col>
         &lt;Col xs="3">
           &lt;RangeSlider
             value={value3}
             onChange={e => setValue3(e.target.value)}
             variant='success'
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="3">
           &lt;RangeSlider
             value={value4}
             onChange={e => setValue4(e.target.value)}
             variant='danger'
-          /&gt;    
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
       &lt;Form.Group as={Row}>
@@ -267,28 +267,28 @@
             value={value5}
             onChange={e => setValue5(e.target.value)}
             variant='warning'
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="3">
           &lt;RangeSlider
             value={value6}
             onChange={e => setValue6(e.target.value)}
             variant='info'
-          /&gt;    
+          /&gt;
         &lt;/Col>
         &lt;Col xs="3">
           &lt;RangeSlider
             value={value7}
             onChange={e => setValue7(e.target.value)}
             variant='dark'
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="3">
           &lt;RangeSlider
             value={value8}
             onChange={e => setValue8(e.target.value)}
             variant='light'
-          /&gt;    
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
     </Form>
@@ -319,21 +319,21 @@
             value={value1}
             onChange={e => setValue1(e.target.value)}
             tooltip='auto'
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="4">
           &lt;RangeSlider
             value={value2}
             onChange={e => setValue2(e.target.value)}
             tooltip='on'
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="4">
           &lt;RangeSlider
             value={value3}
             onChange={e => setValue3(e.target.value)}
             tooltip='off'
-          /&gt;        
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
     &lt;/Form>
@@ -363,7 +363,7 @@
             onChange={e => setValue1(e.target.value)}
             tooltipPlacement='top'
             tooltip='on'
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="6">
           &lt;RangeSlider
@@ -371,7 +371,7 @@
             onChange={e => setValue2(e.target.value)}
             tooltipPlacement='bottom'
             tooltip='on'
-          /&gt;     
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
     &lt;/Form>
@@ -397,7 +397,7 @@
       onChange={e => setValue(e.target.value)}
       tooltipLabel={currentValue => `${currentValue}%`}
       tooltip='on'
-    /&gt;        
+    /&gt;
   );
 
 };</code></pre>
@@ -419,7 +419,7 @@
       value={value}
       onChange={e => setValue(e.target.value)}
       disabled
-    /&gt;        
+    /&gt;
   );
 
 };</code></pre>
@@ -441,7 +441,7 @@
       value={value}
       onChange={e => setValue(e.target.value)}
       step={10}
-    /&gt;         
+    /&gt;
   );
 
 };</code></pre>
@@ -468,7 +468,7 @@
             onChange={e => setValue1(e.target.value)}
             min={1}
             max={5}
-          /&gt;        
+          /&gt;
         &lt;/Col>
         &lt;Col xs="6">
           &lt;RangeSlider
@@ -476,7 +476,7 @@
             onChange={e => setValue2(e.target.value)}
             min={-20}
             max={50}
-          /&gt;     
+          /&gt;
         &lt;/Col>
       &lt;/Form.Group>
     &lt;/Form>
@@ -503,9 +503,37 @@
       onChange={e => setValue(e.target.value)}
       onAfterChange={e => setFinalValue(e.target.value)}
     /&gt;
-    &lt;div&gt;Final value: {finalValue}&lt;/div&gt;   
+    &lt;div&gt;Final value: {finalValue}&lt;/div&gt;
   );
 
+};</code></pre>
+      </div>
+    </section>
+    <section>
+      <h2>Changing tooltip visibility during user interaction</h2>
+      <p>This example shows that the tooltip visibility can be changed as the user interacts with the slider.</p>
+      <div class="example w1" id="ephemeral-tooltip"></div>
+      <div class="code">
+        <button class="toggle"><img src="img/code.svg"></button>
+        <pre><code class="language-jsx">const EphemeralTooltip = () => {
+
+  const [ value, setValue ] = React.useState(0);
+  const [ touched, setTouched ] = React.useState(false);
+
+  return (
+    &lt;RangeSlider
+      value={value}
+      onChange={e => {
+        setValue(e.target.value);
+        setTouched(true);
+      }}
+      onAfterChange={e => {
+        setTouched(false);
+      }}
+      tooltip={touched ? 'off' : 'on'}
+      tooltipLabel={() => 'Choose your amount'}
+    /&gt;
+  );
 };</code></pre>
       </div>
     </section>

--- a/docs/js/examples-umd.js
+++ b/docs/js/examples-umd.js
@@ -1240,61 +1240,17 @@
   });
 
   var DEFAULT_CLASS_PREFIX = 'range-slider';
-  var RangeSlider = /*#__PURE__*/React__default.forwardRef(function (_ref, ref) {
-    var size = _ref.size,
-        _ref$disabled = _ref.disabled,
-        disabled = _ref$disabled === void 0 ? false : _ref$disabled,
-        value = _ref.value,
-        _ref$onChange = _ref.onChange,
-        _onChange = _ref$onChange === void 0 ? function () {} : _ref$onChange,
-        _ref$onAfterChange = _ref.onAfterChange,
-        onAfterChange = _ref$onAfterChange === void 0 ? function () {} : _ref$onAfterChange,
-        _ref$min = _ref.min,
-        min = _ref$min === void 0 ? 0 : _ref$min,
-        _ref$max = _ref.max,
-        max = _ref$max === void 0 ? 100 : _ref$max,
-        step = _ref.step,
-        _ref$variant = _ref.variant,
-        variant = _ref$variant === void 0 ? 'primary' : _ref$variant,
-        _ref$inputProps = _ref.inputProps,
-        inputProps = _ref$inputProps === void 0 ? {} : _ref$inputProps,
-        _ref$tooltip = _ref.tooltip,
-        tooltip = _ref$tooltip === void 0 ? 'auto' : _ref$tooltip,
-        _ref$tooltipPlacement = _ref.tooltipPlacement,
-        tooltipPlacement = _ref$tooltipPlacement === void 0 ? 'bottom' : _ref$tooltipPlacement,
-        tooltipLabel = _ref.tooltipLabel,
-        _ref$tooltipStyle = _ref.tooltipStyle,
-        tooltipStyle = _ref$tooltipStyle === void 0 ? {} : _ref$tooltipStyle,
-        _ref$tooltipProps = _ref.tooltipProps,
-        tooltipProps = _ref$tooltipProps === void 0 ? {} : _ref$tooltipProps,
-        bsPrefix = _ref.bsPrefix,
-        className = _ref.className;
 
-    var _useState = React.useState(),
-        _useState2 = _slicedToArray(_useState, 2),
-        prevValue = _useState2[0],
-        setPrevValue = _useState2[1];
+  var Input = function Input(_ref) {
+    var classes = _ref.classes,
+        _onChange = _ref.onChange,
+        onMouseUpOrTouchEnd = _ref.onMouseUpOrTouchEnd,
+        _onTouchEnd = _ref.onTouchEnd,
+        _onMouseUp = _ref.onMouseUp,
+        rest = _objectWithoutProperties(_ref, ["classes", "onChange", "onMouseUpOrTouchEnd", "onTouchEnd", "onMouseUp"]);
 
-    var prefix = bsPrefix || DEFAULT_CLASS_PREFIX;
-    var isTooltip = tooltip === 'auto' || tooltip === 'on';
-    var classes = classnames(className, prefix, size && "".concat(prefix, "--").concat(size), disabled && 'disabled', variant && "".concat(prefix, "--").concat(variant));
-
-    var _onMouseUp = inputProps.onMouseUp,
-        _onTouchEnd = inputProps.onTouchEnd,
-        restInputProps = _objectWithoutProperties(inputProps, ["onMouseUp", "onTouchEnd"]);
-
-    var onMouseUpOrTouchEnd = function onMouseUpOrTouchEnd(ev) {
-      if (ev.target.value !== prevValue) onAfterChange(ev, ev.target.valueAsNumber);
-      setPrevValue(ev.target.value);
-    };
-
-    var inputEl = /*#__PURE__*/React__default.createElement("input", _extends({
+    return /*#__PURE__*/React__default.createElement("input", _extends({
       type: "range",
-      className: classes,
-      value: value,
-      min: min,
-      max: max,
-      step: step,
       onChange: function onChange(ev) {
         return _onChange(ev, ev.target.valueAsNumber);
       },
@@ -1306,34 +1262,99 @@
         onMouseUpOrTouchEnd(ev);
         if (_onTouchEnd) _onTouchEnd(ev);
       },
+      className: classes
+    }, rest));
+  };
+
+  Input.propTypes = {
+    classes: propTypes.string.isRequired,
+    onChange: propTypes.func.isRequired,
+    onMouseUpOrTouchEnd: propTypes.func.isRequired,
+    onTouchEnd: propTypes.func,
+    onMouseUp: propTypes.func
+  };
+  var InputMemo = /*#__PURE__*/React__default.memo(Input);
+  var RangeSlider = /*#__PURE__*/React__default.forwardRef(function (_ref2, ref) {
+    var size = _ref2.size,
+        _ref2$disabled = _ref2.disabled,
+        disabled = _ref2$disabled === void 0 ? false : _ref2$disabled,
+        value = _ref2.value,
+        _ref2$onChange = _ref2.onChange,
+        onChange = _ref2$onChange === void 0 ? function () {} : _ref2$onChange,
+        _ref2$onAfterChange = _ref2.onAfterChange,
+        onAfterChange = _ref2$onAfterChange === void 0 ? function () {} : _ref2$onAfterChange,
+        _ref2$min = _ref2.min,
+        min = _ref2$min === void 0 ? 0 : _ref2$min,
+        _ref2$max = _ref2.max,
+        max = _ref2$max === void 0 ? 100 : _ref2$max,
+        step = _ref2.step,
+        _ref2$variant = _ref2.variant,
+        variant = _ref2$variant === void 0 ? 'primary' : _ref2$variant,
+        _ref2$inputProps = _ref2.inputProps,
+        inputProps = _ref2$inputProps === void 0 ? {} : _ref2$inputProps,
+        _ref2$tooltip = _ref2.tooltip,
+        tooltip = _ref2$tooltip === void 0 ? 'auto' : _ref2$tooltip,
+        _ref2$tooltipPlacemen = _ref2.tooltipPlacement,
+        tooltipPlacement = _ref2$tooltipPlacemen === void 0 ? 'bottom' : _ref2$tooltipPlacemen,
+        tooltipLabel = _ref2.tooltipLabel,
+        _ref2$tooltipStyle = _ref2.tooltipStyle,
+        tooltipStyle = _ref2$tooltipStyle === void 0 ? {} : _ref2$tooltipStyle,
+        _ref2$tooltipProps = _ref2.tooltipProps,
+        tooltipProps = _ref2$tooltipProps === void 0 ? {} : _ref2$tooltipProps,
+        bsPrefix = _ref2.bsPrefix,
+        className = _ref2.className;
+
+    var _useState = React.useState(),
+        _useState2 = _slicedToArray(_useState, 2),
+        setPrevValue = _useState2[1];
+
+    var prefix = bsPrefix || DEFAULT_CLASS_PREFIX;
+    var isTooltip = tooltip === 'auto' || tooltip === 'on';
+    var classes = classnames(className, prefix, size && "".concat(prefix, "--").concat(size), disabled && 'disabled', variant && "".concat(prefix, "--").concat(variant));
+
+    var onMouseUp = inputProps.onMouseUp,
+        onTouchEnd = inputProps.onTouchEnd,
+        restInputProps = _objectWithoutProperties(inputProps, ["onMouseUp", "onTouchEnd"]);
+
+    var onMouseUpOrTouchEnd = React.useCallback(function (ev) {
+      setPrevValue(function (prevValue) {
+        if (prevValue !== ev.target.value) onAfterChange(ev, ev.target.valueAsNumber);
+        return ev.target.value;
+      });
+    }, [setPrevValue, onAfterChange]);
+    var inputEl = /*#__PURE__*/React__default.createElement(InputMemo, _objectSpread2({
       disabled: disabled,
-      ref: ref
+      value: value,
+      min: min,
+      max: max,
+      ref: ref,
+      step: step,
+      classes: classes,
+      onMouseUpOrTouchEnd: onMouseUpOrTouchEnd,
+      onTouchEnd: onTouchEnd,
+      onMouseUp: onMouseUp,
+      onChange: onChange
     }, restInputProps));
+    var wrapClasses = classnames("".concat(prefix, "__wrap"), size && "".concat(prefix, "__wrap--").concat(size));
+    var tooltipClasses = classnames("".concat(prefix, "__tooltip"), isTooltip && "".concat(prefix, "__tooltip--").concat(tooltip), tooltipPlacement && "".concat(prefix, "__tooltip--").concat(tooltipPlacement), disabled && "".concat(prefix, "__tooltip--disabled"));
+    var thumbRadius = size === 'sm' ? 8 : size === 'lg' ? 12 : 10;
+    var fract = (value - min) / (max - min);
+    var percentLeft = fract * 100;
+    var fractFromCentre = (fract - 0.5) * 2;
+    var adjustment = fractFromCentre * -thumbRadius; // Half thumb width
 
-    if (isTooltip) {
-      var wrapClasses = classnames("".concat(prefix, "__wrap"), size && "".concat(prefix, "__wrap--").concat(size));
-      var tooltipClasses = classnames("".concat(prefix, "__tooltip"), isTooltip && "".concat(prefix, "__tooltip--").concat(tooltip), tooltipPlacement && "".concat(prefix, "__tooltip--").concat(tooltipPlacement), disabled && "".concat(prefix, "__tooltip--disabled"));
-      var thumbRadius = size === 'sm' ? 8 : size === 'lg' ? 12 : 10;
-      var fract = (value - min) / (max - min);
-      var percentLeft = fract * 100;
-      var fractFromCentre = (fract - 0.5) * 2;
-      var adjustment = fractFromCentre * -thumbRadius; // Half thumb width
-
-      return /*#__PURE__*/React__default.createElement("span", {
-        className: wrapClasses
-      }, inputEl, /*#__PURE__*/React__default.createElement("div", _extends({
-        className: tooltipClasses,
-        style: _objectSpread2(_objectSpread2({}, tooltipStyle || {}), {}, {
-          left: "calc(".concat(percentLeft, "% + ").concat(adjustment, "px)")
-        })
-      }, tooltipProps), /*#__PURE__*/React__default.createElement("div", {
-        className: "".concat(prefix, "__tooltip__label")
-      }, tooltipLabel ? tooltipLabel(value) : value), /*#__PURE__*/React__default.createElement("div", {
-        className: "".concat(prefix, "__tooltip__arrow")
-      })));
-    } else {
-      return inputEl;
-    }
+    return /*#__PURE__*/React__default.createElement("span", {
+      className: wrapClasses
+    }, inputEl, isTooltip && /*#__PURE__*/React__default.createElement("div", _extends({
+      className: tooltipClasses,
+      style: _objectSpread2(_objectSpread2({}, tooltipStyle || {}), {}, {
+        left: "calc(".concat(percentLeft, "% + ").concat(adjustment, "px)")
+      })
+    }, tooltipProps), /*#__PURE__*/React__default.createElement("div", {
+      className: "".concat(prefix, "__tooltip__label")
+    }, tooltipLabel ? tooltipLabel(value) : value), /*#__PURE__*/React__default.createElement("div", {
+      className: "".concat(prefix, "__tooltip__arrow")
+    })));
   }); // Fix: https://github.com/jaywilz/react-bootstrap-range-slider/issues/3
 
   var Element = typeof Element === 'undefined' ? function () {} : Element;

--- a/docs/js/examples.js
+++ b/docs/js/examples.js
@@ -459,6 +459,33 @@ var AfterChange = function AfterChange() {
   }), /*#__PURE__*/React.createElement("div", null, "Final value: ", finalValue));
 };
 
+var EphemeralTooltip = function EphemeralTooltip() {
+  var _React$useState55 = React.useState(0),
+      _React$useState56 = _slicedToArray(_React$useState55, 2),
+      value = _React$useState56[0],
+      setValue = _React$useState56[1];
+
+  var _React$useState57 = React.useState(false),
+      _React$useState58 = _slicedToArray(_React$useState57, 2),
+      touched = _React$useState58[0],
+      setTouched = _React$useState58[1];
+
+  return /*#__PURE__*/React.createElement(RangeSlider, {
+    value: value,
+    onChange: function onChange(e) {
+      setValue(e.target.value);
+      setTouched(true);
+    },
+    onAfterChange: function onAfterChange(e) {
+      setTouched(false);
+    },
+    tooltip: touched ? 'off' : 'on',
+    tooltipLabel: function tooltipLabel() {
+      return 'Choose your amount';
+    }
+  });
+};
+
 ReactDOM.render( /*#__PURE__*/React.createElement(SimpleSlider, null), document.getElementById('simple-usage'));
 ReactDOM.render( /*#__PURE__*/React.createElement(SliderWithLabel, null), document.getElementById('with-label'));
 ReactDOM.render( /*#__PURE__*/React.createElement(SliderWithColumnLayoutLabel, null), document.getElementById('with-column-layout-label'));
@@ -472,3 +499,4 @@ ReactDOM.render( /*#__PURE__*/React.createElement(Disabled, null), document.getE
 ReactDOM.render( /*#__PURE__*/React.createElement(Step, null), document.getElementById('step'));
 ReactDOM.render( /*#__PURE__*/React.createElement(MinMax, null), document.getElementById('min-max'));
 ReactDOM.render( /*#__PURE__*/React.createElement(AfterChange, null), document.getElementById('after-change'));
+ReactDOM.render( /*#__PURE__*/React.createElement(EphemeralTooltip, null), document.getElementById('ephemeral-tooltip'));

--- a/docs/js/examples.src.js
+++ b/docs/js/examples.src.js
@@ -18,8 +18,8 @@ const SliderWithLabel = () => {
 
   const [ value, setValue ] = React.useState(50);
 
-  return ( 
-    <Form> 
+  return (
+    <Form>
       <Form.Group>
         <Form.Label>
           My Label
@@ -28,7 +28,7 @@ const SliderWithLabel = () => {
           value={value}
           onChange={e => setValue(e.target.value)}
         />
-      </Form.Group>   
+      </Form.Group>
     </Form>
   );
 
@@ -38,8 +38,8 @@ const SliderWithColumnLayoutLabel = () => {
 
   const [ value, setValue ] = React.useState(50);
 
-  return ( 
-    <Form> 
+  return (
+    <Form>
       <Form.Group as={Row}>
         <Form.Label column sm='4'>
           My Other Label
@@ -67,7 +67,7 @@ const SliderWithInputFormControl = () => {
           <RangeSlider
             value={value}
             onChange={e => setValue(e.target.value)}
-          />        
+          />
         </Col>
         <Col xs='3'>
           <Form.Control
@@ -102,7 +102,7 @@ const Sizes = () => {
             value={value1}
             onChange={e => setValue1(e.target.value)}
             size='sm'
-          />        
+          />
         </Col>
       </Form.Group>
       <Form.Group as={Row}>
@@ -116,7 +116,7 @@ const Sizes = () => {
           <RangeSlider
             value={value2}
             onChange={e => setValue2(e.target.value)}
-          />        
+          />
         </Col>
       </Form.Group>
       <Form.Group as={Row}>
@@ -132,7 +132,7 @@ const Sizes = () => {
             value={value3}
             onChange={e => setValue3(e.target.value)}
             size='lg'
-          />        
+          />
         </Col>
       </Form.Group>
      </Form>
@@ -159,28 +159,28 @@ const Variants = () => {
             value={value1}
             onChange={e => setValue1(e.target.value)}
             variant='primary'
-          />        
+          />
         </Col>
         <Col xs='3'>
           <RangeSlider
             value={value2}
             onChange={e => setValue2(e.target.value)}
             variant='secondary'
-          />    
+          />
         </Col>
         <Col xs='3'>
           <RangeSlider
             value={value3}
             onChange={e => setValue3(e.target.value)}
             variant='success'
-          />        
+          />
         </Col>
         <Col xs='3'>
           <RangeSlider
             value={value4}
             onChange={e => setValue4(e.target.value)}
             variant='danger'
-          />    
+          />
         </Col>
       </Form.Group>
       <Form.Group as={Row}>
@@ -189,28 +189,28 @@ const Variants = () => {
             value={value5}
             onChange={e => setValue5(e.target.value)}
             variant='warning'
-          />        
+          />
         </Col>
         <Col xs='3'>
           <RangeSlider
             value={value6}
             onChange={e => setValue6(e.target.value)}
             variant='info'
-          />    
+          />
         </Col>
         <Col xs='3'>
           <RangeSlider
             value={value7}
             onChange={e => setValue7(e.target.value)}
             variant='dark'
-          />        
+          />
         </Col>
         <Col xs='3'>
           <RangeSlider
             value={value8}
             onChange={e => setValue8(e.target.value)}
             variant='light'
-          />    
+          />
         </Col>
       </Form.Group>
    </Form>
@@ -232,21 +232,21 @@ const TooltipBehaviour = () => {
             value={value1}
             onChange={e => setValue1(e.target.value)}
             tooltip='auto'
-          />        
+          />
         </Col>
         <Col xs='4'>
           <RangeSlider
             value={value2}
             onChange={e => setValue2(e.target.value)}
             tooltip='on'
-          />        
+          />
         </Col>
         <Col xs='4'>
           <RangeSlider
             value={value3}
             onChange={e => setValue3(e.target.value)}
             tooltip='off'
-          />        
+          />
         </Col>
       </Form.Group>
     </Form>
@@ -268,7 +268,7 @@ const TooltipPlacement = () => {
             onChange={e => setValue1(e.target.value)}
             tooltipPlacement='top'
             tooltip='on'
-          />        
+          />
         </Col>
         <Col xs='6'>
           <RangeSlider
@@ -276,7 +276,7 @@ const TooltipPlacement = () => {
             onChange={e => setValue2(e.target.value)}
             tooltipPlacement='bottom'
             tooltip='on'
-          />     
+          />
         </Col>
       </Form.Group>
     </Form>
@@ -294,7 +294,7 @@ const TooltipLabel = () => {
       onChange={e => setValue(e.target.value)}
       tooltipLabel={currentValue => `${currentValue}%`}
       tooltip='on'
-    />        
+    />
   );
 
 };
@@ -308,7 +308,7 @@ const Disabled = () => {
       value={value}
       onChange={e => setValue(e.target.value)}
       disabled
-    />         
+    />
   );
 
 };
@@ -322,7 +322,7 @@ const Step = () => {
       value={value}
       onChange={e => setValue(e.target.value)}
       step={10}
-    />         
+    />
   );
 
 };
@@ -341,7 +341,7 @@ const MinMax = () => {
             onChange={e => setValue1(e.target.value)}
             min={1}
             max={5}
-          />        
+          />
         </Col>
         <Col xs='6'>
           <RangeSlider
@@ -349,7 +349,7 @@ const MinMax = () => {
             onChange={e => setValue2(e.target.value)}
             min={-20}
             max={50}
-          />     
+          />
         </Col>
       </Form.Group>
     </Form>
@@ -371,9 +371,29 @@ const AfterChange = () => {
         tooltipPlacement='top'
       />
       <div>Final value: {finalValue}</div>
-    </> 
+    </>
   );
 
+};
+
+const EphemeralTooltip = () => {
+  const [ value, setValue ] = React.useState(0);
+  const [ touched, setTouched ] = React.useState(false);
+
+  return (
+    <RangeSlider
+      value={value}
+      onChange={e => {
+        setValue(e.target.value);
+        setTouched(true);
+      }}
+      onAfterChange={e => {
+          setTouched(false);
+      }}
+      tooltip={touched ? 'off' : 'on'}
+      tooltipLabel={() => 'Choose your amount'}
+    />
+  );
 };
 
 ReactDOM.render(
@@ -439,4 +459,9 @@ ReactDOM.render(
 ReactDOM.render(
   <AfterChange/>,
   document.getElementById('after-change'),
+);
+
+ReactDOM.render(
+  <EphemeralTooltip />,
+  document.getElementById('ephemeral-tooltip')
 );


### PR DESCRIPTION
Hi, cheers for the great library.

We've got a use case where we want to use the tooltip as a helper prompt for our users, which disappears after the user has interacted with the slider.  To do this, we're changing the `tooltip` prop from `"on"` to `"off"` after the first interaction, but changing this prop also makes the range `<input>` itself re-render, which results in the dragging action getting stuck - the user has to release the mouse/touch, and then pick the thumb slider back up to change the value beyond that very first change.  It's a little hard to describe but the first commit in this PR adds an example to the docs which shows this issue (the second commit is the fix).

I've tried to stick to the existing code style, and I tested in Chromium and Firefox (these are the only 2 browsers I have access to at the moment). I couldn't get the unit tests to run as Jest was complaining about a syntax error with a style import.
